### PR TITLE
Fix missing `extension` in produced `.module` file

### DIFF
--- a/lazythreetenbp/build.gradle
+++ b/lazythreetenbp/build.gradle
@@ -54,7 +54,7 @@ tasks.named("generateLazyZoneRules") {
 dependencies {
     tickTockCompiler libs.ticktock.compiler
     compileOnly libs.annotation.core
-    implementation(libs.threetenbp.core) { artifact { classifier = 'no-tzdb' } }
+    implementation("org.threeten:threetenbp:1.6.4:no-tzdb")
 
     androidTestImplementation libs.junit.core
     androidTestImplementation libs.truth.core


### PR DESCRIPTION
Workaround https://github.com/gradle/gradle/issues/21526